### PR TITLE
Create wiki-inspired tree UI prototype

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1,42 +1,190 @@
-#root {
-  max-width: 1280px;
-  margin: 0 auto;
-  padding: 2rem;
-  text-align: center;
+.app {
+  min-height: 100vh;
+  background: radial-gradient(circle at 20% 20%, #0f172a, #0b1221 40%), #0b1221;
+  color: #e2e8f0;
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  padding: 2.5rem clamp(1.5rem, 3vw, 3rem);
 }
 
-.logo {
-  height: 6em;
-  padding: 1.5em;
-  will-change: filter;
-  transition: filter 300ms;
-}
-.logo:hover {
-  filter: drop-shadow(0 0 2em #646cffaa);
-}
-.logo.react:hover {
-  filter: drop-shadow(0 0 2em #61dafbaa);
+.panel {
+  max-width: 960px;
+  margin: 0 auto 1.75rem;
+  background: linear-gradient(145deg, rgba(30, 41, 59, 0.8), rgba(15, 23, 42, 0.85));
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  border-radius: 18px;
+  padding: 1.75rem 1.5rem;
+  box-shadow: 0 12px 45px rgba(0, 0, 0, 0.35);
+  backdrop-filter: blur(10px);
 }
 
-@keyframes logo-spin {
-  from {
-    transform: rotate(0deg);
+.panel h1 {
+  margin: 0.35rem 0 0.75rem;
+  font-size: clamp(1.6rem, 3vw, 2rem);
+  letter-spacing: -0.02em;
+}
+
+.panel p {
+  margin: 0;
+  color: #cbd5e1;
+  line-height: 1.6;
+}
+
+.pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.35rem 0.85rem;
+  border-radius: 999px;
+  font-size: 0.875rem;
+  letter-spacing: -0.01em;
+  background: rgba(125, 211, 252, 0.1);
+  color: #7dd3fc;
+  border: 1px solid rgba(125, 211, 252, 0.4);
+}
+
+.quick-spec {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  margin-top: 1rem;
+}
+
+.quick-spec span {
+  padding: 0.4rem 0.85rem;
+  border-radius: 12px;
+  background: rgba(148, 163, 184, 0.12);
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  color: #e2e8f0;
+  font-size: 0.9rem;
+}
+
+.workspace {
+  position: relative;
+  overflow: hidden;
+  border-radius: 22px;
+  border: 1px solid rgba(148, 163, 184, 0.15);
+  background: radial-gradient(circle at 30% 30%, rgba(56, 189, 248, 0.08), transparent 45%),
+    radial-gradient(circle at 70% 40%, rgba(139, 92, 246, 0.1), transparent 40%),
+    #0b1221;
+  height: 720px;
+  box-shadow: 0 16px 55px rgba(0, 0, 0, 0.4);
+}
+
+.grid {
+  position: absolute;
+  inset: 0;
+  background-image: radial-gradient(rgba(30, 41, 59, 0.8) 1px, transparent 1px);
+  background-size: 20px 20px;
+  mask-image: radial-gradient(ellipse at center, rgba(0, 0, 0, 0.9), transparent 70%);
+}
+
+.connections {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+}
+
+.connections path {
+  fill: none;
+  stroke-width: 2.25;
+  opacity: 0.9;
+  filter: drop-shadow(0 0 6px rgba(59, 130, 246, 0.25));
+}
+
+.node-card {
+  position: absolute;
+  width: 220px;
+  padding: 14px 16px 16px;
+  border-radius: 18px;
+  border: 1px solid rgba(148, 163, 184, 0.3);
+  background: rgba(15, 23, 42, 0.92);
+  backdrop-filter: blur(8px);
+  box-shadow: 0 10px 40px rgba(0, 0, 0, 0.35);
+  transition: transform 220ms ease, border-color 220ms ease, box-shadow 220ms ease;
+}
+
+.node-card:hover {
+  transform: translateY(-4px) scale(1.02);
+  border-color: rgba(125, 211, 252, 0.6);
+  box-shadow: 0 16px 50px rgba(14, 165, 233, 0.2);
+}
+
+.node-card--selected {
+  transform: translateY(-2px) scale(1.06);
+  border-color: #7dd3fc;
+  box-shadow: 0 20px 55px rgba(125, 211, 252, 0.25), 0 0 0 1px rgba(125, 211, 252, 0.2);
+}
+
+.node-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-weight: 600;
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  padding: 6px 10px;
+  border-radius: 999px;
+  background: rgba(148, 163, 184, 0.1);
+  border: 1px solid rgba(148, 163, 184, 0.3);
+}
+
+.node-title {
+  margin-top: 10px;
+  font-size: 18px;
+  font-weight: 700;
+  color: #e5e7eb;
+  letter-spacing: -0.02em;
+}
+
+.node-detail {
+  margin-top: 6px;
+  font-size: 14px;
+  color: #cbd5e1;
+  line-height: 1.45;
+}
+
+.legend {
+  position: absolute;
+  right: 20px;
+  bottom: 18px;
+  display: flex;
+  gap: 18px;
+  align-items: center;
+  padding: 12px 14px;
+  border-radius: 14px;
+  background: rgba(15, 23, 42, 0.85);
+  border: 1px solid rgba(148, 163, 184, 0.2);
+}
+
+.legend div {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  color: #e2e8f0;
+  font-size: 0.95rem;
+}
+
+.legend-dot {
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  background: #94a3b8;
+  box-shadow: 0 0 0 3px rgba(148, 163, 184, 0.15);
+}
+
+.legend-dot--accent {
+  background: linear-gradient(135deg, #7dd3fc, #8b5cf6);
+  box-shadow: 0 0 0 3px rgba(125, 211, 252, 0.2);
+}
+
+@media (max-width: 860px) {
+  .workspace {
+    height: 620px;
   }
-  to {
-    transform: rotate(360deg);
+
+  .node-card {
+    transform: scale(0.95);
   }
-}
-
-@media (prefers-reduced-motion: no-preference) {
-  a:nth-of-type(2) .logo {
-    animation: logo-spin infinite 20s linear;
-  }
-}
-
-.card {
-  padding: 2em;
-}
-
-.read-the-docs {
-  color: #888;
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,34 +1,134 @@
-import { useState } from 'react'
-import reactLogo from './assets/react.svg'
-import viteLogo from '/vite.svg'
 import './App.css'
 
+const nodes = [
+  {
+    id: 'start',
+    title: '시작 문서',
+    detail: '위키레이싱 시작점 · 나무위키 스타일 트리',
+    x: 160,
+    y: 160,
+    selected: true,
+    accent: '#7dd3fc',
+  },
+  {
+    id: 'a',
+    title: '링크 문서 A',
+    detail: 'n8n 곡선 라인 · 카드형 노드',
+    x: 440,
+    y: 260,
+    accent: '#93c5fd',
+  },
+  {
+    id: 'b',
+    title: '링크 문서 B',
+    detail: '선택 시 강조 · Tailwind 톤앤매너',
+    x: 420,
+    y: 420,
+    accent: '#a5b4fc',
+  },
+  {
+    id: 'c',
+    title: '링크 문서 C',
+    detail: '리더보드/경로 시각화로 확장',
+    x: 660,
+    y: 340,
+    accent: '#f9a8d4',
+  },
+]
+
+const connections = [
+  { from: 'start', to: 'a', color: '#60a5fa' },
+  { from: 'start', to: 'b', color: '#8b5cf6' },
+  { from: 'a', to: 'c', color: '#f472b6' },
+]
+
+type NodeProps = {
+  id: string
+  title: string
+  detail: string
+  x: number
+  y: number
+  selected?: boolean
+  accent?: string
+}
+
+function NodeCard({ title, detail, x, y, selected, accent }: NodeProps) {
+  return (
+    <div
+      className={`node-card ${selected ? 'node-card--selected' : ''}`}
+      style={{ left: x, top: y, borderColor: accent }}
+    >
+      <div className="node-pill" style={{ color: accent }}>
+        링크 노드
+      </div>
+      <div className="node-title">{title}</div>
+      <div className="node-detail">{detail}</div>
+    </div>
+  )
+}
+
+function buildPath(from: NodeProps, to: NodeProps) {
+  const startX = from.x + 140
+  const startY = from.y + 50
+  const endX = to.x + 0
+  const endY = to.y + 40
+  const offset = (endX - startX) * 0.35
+
+  return `M ${startX} ${startY} C ${startX + offset} ${startY}, ${endX - offset} ${endY}, ${endX} ${endY}`
+}
+
 function App() {
-  const [count, setCount] = useState(0)
+  const nodeMap = Object.fromEntries(nodes.map((node) => [node.id, node]))
 
   return (
-    <>
-      <div>
-        <a href="https://vite.dev" target="_blank">
-          <img src={viteLogo} className="logo" alt="Vite logo" />
-        </a>
-        <a href="https://react.dev" target="_blank">
-          <img src={reactLogo} className="logo react" alt="React logo" />
-        </a>
-      </div>
-      <h1>Vite + React</h1>
-      <div className="card">
-        <button onClick={() => setCount((count) => count + 1)}>
-          count is {count}
-        </button>
+    <div className="app">
+      <div className="panel">
+        <div className="pill">Wiki 안내</div>
+        <h1>WikiRacing · n8n 스타일 트리 UI</h1>
         <p>
-          Edit <code>src/App.tsx</code> and save to test HMR
+          레포 Wiki에서 설명한 것처럼 링크 구조를 트리로 확장하고, 선택된 노드를 강조하는 Tailwind 톤의
+          미니멀 UI 프로토타입입니다. 나무위키 링크 흐름과 리더보드/경로 시각화를 위한 베이스로 사용할 수
+          있도록 카드형 노드와 곡선 SVG 라인을 함께 배치했습니다.
         </p>
+        <div className="quick-spec">
+          <span>곡선 연결</span>
+          <span>카드형 노드</span>
+          <span>선택 강조</span>
+          <span>다크 + 그리드</span>
+        </div>
       </div>
-      <p className="read-the-docs">
-        Click on the Vite and React logos to learn more
-      </p>
-    </>
+
+      <div className="workspace">
+        <div className="grid" aria-hidden />
+        <svg className="connections" aria-hidden>
+          {connections.map((edge) => {
+            const from = nodeMap[edge.from]
+            const to = nodeMap[edge.to]
+
+            if (!from || !to) return null
+
+            return (
+              <path key={`${edge.from}-${edge.to}`} d={buildPath(from, to)} stroke={edge.color} />
+            )
+          })}
+        </svg>
+
+        {nodes.map((node) => (
+          <NodeCard key={node.id} {...node} />
+        ))}
+
+        <div className="legend">
+          <div>
+            <div className="legend-dot" />
+            <span>Wiki 링크 확장</span>
+          </div>
+          <div>
+            <div className="legend-dot legend-dot--accent" />
+            <span>선택된 노드 강조</span>
+          </div>
+        </div>
+      </div>
+    </div>
   )
 }
 

--- a/src/index.css
+++ b/src/index.css
@@ -1,68 +1,32 @@
 :root {
-  font-family: system-ui, Avenir, Helvetica, Arial, sans-serif;
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
   line-height: 1.5;
   font-weight: 400;
-
-  color-scheme: light dark;
-  color: rgba(255, 255, 255, 0.87);
-  background-color: #242424;
-
-  font-synthesis: none;
+  color: #e2e8f0;
+  background-color: #0b1221;
   text-rendering: optimizeLegibility;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }
 
 a {
-  font-weight: 500;
-  color: #646cff;
-  text-decoration: inherit;
+  color: inherit;
 }
+
 a:hover {
-  color: #535bf2;
+  color: #7dd3fc;
+}
+
+* {
+  box-sizing: border-box;
 }
 
 body {
   margin: 0;
-  display: flex;
-  place-items: center;
-  min-width: 320px;
   min-height: 100vh;
+  background: #0b1221;
 }
 
-h1 {
-  font-size: 3.2em;
-  line-height: 1.1;
-}
-
-button {
-  border-radius: 8px;
-  border: 1px solid transparent;
-  padding: 0.6em 1.2em;
-  font-size: 1em;
-  font-weight: 500;
-  font-family: inherit;
-  background-color: #1a1a1a;
-  cursor: pointer;
-  transition: border-color 0.25s;
-}
-button:hover {
-  border-color: #646cff;
-}
-button:focus,
-button:focus-visible {
-  outline: 4px auto -webkit-focus-ring-color;
-}
-
-@media (prefers-color-scheme: light) {
-  :root {
-    color: #213547;
-    background-color: #ffffff;
-  }
-  a:hover {
-    color: #747bff;
-  }
-  button {
-    background-color: #f9f9f9;
-  }
+#root {
+  min-height: 100vh;
 }


### PR DESCRIPTION
## Summary
- replace default Vite counter page with WikiRacing-inspired node tree prototype using SVG curves and card nodes
- add dark n8n-like styling with grid backdrop, legend, and emphasis on selected nodes
- refresh global styles to match the minimal Tailwind-toned presentation described in the repo wiki

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692eb43d92f4832e9d3902123829dfad)