### PR TITLE
Enhance history navigation and branching UI

### DIFF
--- a/src/components/GameHeader.tsx
+++ b/src/components/GameHeader.tsx
@@ -10,10 +10,11 @@ interface GameHeaderProps {
   currentDoc: WikiDocument;
   goalDoc: WikiDocument;
   onBack: () => void;
+  onJumpToNode: (nodeId: string) => void;
   isLoading?: boolean;
 }
 
-export function GameHeader({ gameState, startDoc, currentDoc, goalDoc, onBack, isLoading = false }: GameHeaderProps) {
+export function GameHeader({ gameState, startDoc, currentDoc, goalDoc, onBack, onJumpToNode, isLoading = false }: GameHeaderProps) {
   const [elapsedTime, setElapsedTime] = useState(0);
   const [showHistoryPopup, setShowHistoryPopup] = useState(false);
 
@@ -32,7 +33,8 @@ export function GameHeader({ gameState, startDoc, currentDoc, goalDoc, onBack, i
     return `${mins}:${secs.toString().padStart(2, '0')}`;
   };
 
-  const canGoBack = gameState.path.length > 1 && (gameState.allowBacktracking ?? true);
+  const allowBacktracking = gameState.allowBacktracking ?? true;
+  const canGoBack = gameState.path.length > 1 && allowBacktracking;
 
   // 로딩 상태 렌더링
   if (isLoading) {
@@ -165,7 +167,7 @@ export function GameHeader({ gameState, startDoc, currentDoc, goalDoc, onBack, i
         <>
           {/* 오버레이 - 흐릿한 배경 */}
           <div
-            className="fixed inset-0 bg-black bg-opacity-10 backdrop-blur-sm z-40"
+            className="fixed inset-0 bg-black/30 backdrop-blur-md z-40 transition-opacity"
             onClick={() => setShowHistoryPopup(false)}
           />
 
@@ -190,19 +192,30 @@ export function GameHeader({ gameState, startDoc, currentDoc, goalDoc, onBack, i
 
                 return (
                   <div key={`history-${index}`} className="flex items-center">
-                    <span
-                      className={`text-sm px-2 py-1 rounded ${
+                    <button
+                      type="button"
+                      onClick={() => {
+                        if (!allowBacktracking) return;
+                        onJumpToNode(docId);
+                        setShowHistoryPopup(false);
+                      }}
+                      disabled={!allowBacktracking || isCurrent}
+                      className={`text-sm px-2 py-1 rounded transition-colors ${
                         isStart
                           ? 'bg-gray-100 text-gray-700 font-medium'
                           : isCurrent
                           ? 'bg-red-50 text-red-600 font-bold'
                           : isGoal
                           ? 'bg-green-50 text-green-600 font-bold'
-                          : 'bg-gray-50 text-gray-600'
+                          : 'bg-gray-50 text-gray-600 hover:bg-gray-100'
+                      } ${
+                        !allowBacktracking || isCurrent
+                          ? 'cursor-not-allowed opacity-70'
+                          : 'cursor-pointer'
                       }`}
                     >
                       {doc?.title || 'unknown'}
-                    </span>
+                    </button>
                     {index < gameState.path.length - 1 && (
                       <span className="text-gray-400 mx-1">→</span>
                     )}

--- a/src/components/PathHistory.tsx
+++ b/src/components/PathHistory.tsx
@@ -1,6 +1,9 @@
+import { useMemo } from 'react';
 import type { GameState } from '../types/wikirace';
 import { mockWikiDocuments } from '../data/mockWikiData';
 import { ScrollArea } from './ui/scroll-area';
+
+const COLUMN_WIDTH = 18;
 
 interface PathHistoryProps {
   gameState: GameState;
@@ -8,43 +11,107 @@ interface PathHistoryProps {
   onToggle?: () => void;
 }
 
+interface HistoryEntry {
+  docId: string;
+  depth: number;
+  previousDepth: number;
+  index: number;
+  isLast: boolean;
+}
+
 export function PathHistory({ gameState, onNodeClick, onToggle }: PathHistoryProps) {
+  const history = gameState.historyLog ?? gameState.path;
+
+  const { entries, maxDepth } = useMemo(() => {
+    if (history.length === 0) {
+      return { entries: [] as HistoryEntry[], maxDepth: 0 };
+    }
+
+    const stack: string[] = [history[0]];
+    let previousDepth = 0;
+    let maxDepthLocal = 0;
+
+    const mapped: HistoryEntry[] = history.map((docId, index) => {
+      if (index > 0) {
+        const existingIndex = stack.lastIndexOf(docId);
+        if (existingIndex !== -1) {
+          // 이전에 방문했던 노드로 돌아온 경우, 해당 지점 이후 스택을 잘라냄
+          stack.splice(existingIndex + 1);
+        } else {
+          stack.push(docId);
+        }
+      }
+
+      const depth = stack.length - 1;
+      maxDepthLocal = Math.max(maxDepthLocal, depth);
+
+      const entry: HistoryEntry = {
+        docId,
+        depth,
+        previousDepth,
+        index,
+        isLast: index === history.length - 1,
+      };
+
+      previousDepth = depth;
+      return entry;
+    });
+
+    return { entries: mapped, maxDepth: maxDepthLocal };
+  }, [history]);
+
   return (
-    <div className="w-80 bg-white border-l flex flex-col">
-      <div className="p-4 border-b">
+    <div className="w-80 bg-white border-l flex flex-col max-h-screen h-full overflow-hidden">
+      <div className="p-4 border-b bg-white sticky top-0 z-10">
         <h3 className="text-sm font-semibold text-gray-900">방문 기록</h3>
-        <div className="text-xs text-gray-500 mt-1">
-          총 {gameState.path.length}개 문서 방문
-        </div>
+        <div className="text-xs text-gray-500 mt-1">총 {history.length}개 문서 방문</div>
       </div>
 
-      <ScrollArea className="flex-1">
-        <div className="p-4">
-          {/* Git Branch 스타일 시각화 - Figma 디자인 */}
-          {gameState.path.map((docId, index) => {
-            const doc = mockWikiDocuments[docId];
-            const isStart = docId === gameState.startDocId;
-            const isGoal = docId === gameState.goalDocId;
-            const isCurrent = index === gameState.path.length - 1;
-            const isLast = index === gameState.path.length - 1;
+      <ScrollArea className="flex-1 min-h-0">
+        <div className="p-4 space-y-4">
+          {entries.map((entry) => {
+            const doc = mockWikiDocuments[entry.docId];
+            const isStart = entry.docId === gameState.startDocId;
+            const isGoal = entry.docId === gameState.goalDocId;
+            const isCurrent = entry.index === history.length - 1 && entry.docId === gameState.currentDocId;
 
-            // 색상 결정 (Figma: 분홍/노란/초록)
             let dotColor = 'bg-pink-400';
             if (isCurrent) dotColor = 'bg-yellow-400';
             if (isGoal) dotColor = 'bg-green-500';
 
+            const dotLeft = entry.depth * COLUMN_WIDTH;
+            const prevLeft = entry.previousDepth * COLUMN_WIDTH;
+            const horizontalWidth = Math.abs(dotLeft - prevLeft);
+            const horizontalStart = Math.min(dotLeft, prevLeft) + 8;
+            const graphWidth = (maxDepth + 1) * COLUMN_WIDTH + 12;
+
             return (
-              <div key={`${docId}-${index}`} className="relative flex items-start gap-3">
-                {/* Git Branch 연결선 */}
-                {!isLast && (
-                  <div className="absolute left-2 top-6 bottom-0 w-0.5 bg-gray-300" />
-                )}
+              <div key={`${entry.docId}-${entry.index}`} className="relative flex items-start gap-3">
+                <div className="relative" style={{ width: graphWidth }}>
+                  {!entry.isLast && (
+                    <div
+                      className="absolute top-6 bottom-0 w-px bg-gray-300"
+                      style={{ left: dotLeft + 8 }}
+                    />
+                  )}
 
-                {/* Git 스타일 점 */}
-                <div className={`relative z-10 w-4 h-4 rounded-full ${dotColor} flex-shrink-0 mt-1`} />
+                  {entry.index > 0 && entry.depth !== entry.previousDepth && (
+                    <div
+                      className="absolute top-3 h-px bg-gray-300"
+                      style={{ left: horizontalStart, width: horizontalWidth + 8 }}
+                    />
+                  )}
 
-                {/* 문서 정보 */}
-                <div className="flex-1 pb-4">
+                  <div
+                    className={`relative z-10 w-4 h-4 rounded-full ${dotColor} flex-shrink-0 mt-1 border-2 border-white shadow-sm`}
+                    style={{ transform: `translateX(${dotLeft}px)` }}
+                  />
+                </div>
+
+                <div
+                  className={`flex-1 pb-4 ${onNodeClick ? 'cursor-pointer' : ''}`}
+                  onClick={() => onNodeClick?.(entry.docId)}
+                >
                   <div className={`text-sm ${isCurrent ? 'font-semibold text-gray-900' : 'text-gray-700'}`}>
                     {doc?.title || '알 수 없음'}
                   </div>
@@ -52,7 +119,7 @@ export function PathHistory({ gameState, onNodeClick, onToggle }: PathHistoryPro
                     {isStart && '시작 문서'}
                     {isGoal && '목표 문서'}
                     {isCurrent && !isGoal && '현재 위치'}
-                    {!isStart && !isGoal && !isCurrent && `단계 ${index + 1}`}
+                    {!isStart && !isGoal && !isCurrent && `단계 ${entry.index + 1}`}
                   </div>
                 </div>
               </div>
@@ -61,7 +128,6 @@ export function PathHistory({ gameState, onNodeClick, onToggle }: PathHistoryPro
         </div>
       </ScrollArea>
 
-      {/* 하단 닫기 버튼 */}
       <div className="p-4 border-t bg-gray-50">
         <button
           onClick={onToggle}

--- a/src/components/WikiRaceGame.tsx
+++ b/src/components/WikiRaceGame.tsx
@@ -16,6 +16,7 @@ export function WikiRaceGame() {
     startNewGame,
     navigateTo,
     goBack,
+    jumpToNode,
     status,
     allowBacktracking,
     gameMode,
@@ -25,7 +26,7 @@ export function WikiRaceGame() {
 
   const [visualNodes, setVisualNodes] = useState<VisualNode[]>([]);
   const [showLeaderboard, setShowLeaderboard] = useState(false);
-  const [showPathHistory, setShowPathHistory] = useState(true);
+  const [showPathHistory, setShowPathHistory] = useState(false);
   const [isLoadingNodes, setIsLoadingNodes] = useState(false);
 
   useEffect(() => {
@@ -198,6 +199,7 @@ export function WikiRaceGame() {
         currentDoc={currentDoc}
         goalDoc={goalDoc}
         onBack={goBack}
+        onJumpToNode={jumpToNode}
       />
 
       <div className="flex-1 flex overflow-hidden">

--- a/src/gameStore.ts
+++ b/src/gameStore.ts
@@ -17,6 +17,7 @@ interface GameActions {
   startNewGame: () => void;
   navigateTo: (nodeId: string) => void;
   goBack: () => void;
+  jumpToNode: (nodeId: string) => void;
   setAllowBacktracking: (allow: boolean) => void;
   setGameMode: (mode: 'easy' | 'challenge') => void;
 }
@@ -26,6 +27,7 @@ const initialState: GameState & GameSettings = {
   goalDocId: null,
   currentDocId: null,
   path: [],
+  historyLog: [],
   moves: 0,
   startTime: null,
   status: 'idle',
@@ -50,6 +52,7 @@ export const useGameStore = create<GameState & GameSettings & GameActions>((set,
       goalDocId: scenario.goal,
       currentDocId: scenario.start,
       path: [scenario.start],
+      historyLog: [scenario.start],
       moves: 0,
       startTime: Date.now(),
       status: 'playing',
@@ -71,6 +74,7 @@ export const useGameStore = create<GameState & GameSettings & GameActions>((set,
 
     // 이미 방문한 노드를 다시 방문하는 것도 허용 (위키레이싱에서는 일반적)
     const newPath = [...state.path, nodeId];
+    const newHistory = [...state.historyLog, nodeId];
     const newMoves = state.moves + 1;
 
     // 목표 도달 여부 확인
@@ -82,6 +86,7 @@ export const useGameStore = create<GameState & GameSettings & GameActions>((set,
       set({
         currentDocId: nodeId,
         path: newPath,
+        historyLog: newHistory,
         moves: newMoves,
         status: 'finished',
         endTime,
@@ -91,6 +96,7 @@ export const useGameStore = create<GameState & GameSettings & GameActions>((set,
       set({
         currentDocId: nodeId,
         path: newPath,
+        historyLog: newHistory,
         moves: newMoves,
       });
     }
@@ -110,6 +116,28 @@ export const useGameStore = create<GameState & GameSettings & GameActions>((set,
       currentDocId: newCurrentId,
       path: newPath,
       moves: state.moves + 1, // 뒤로가기도 이동 횟수에 포함
+      historyLog: [...state.historyLog, newCurrentId],
+    });
+  },
+
+  jumpToNode: (nodeId) => {
+    const state = get();
+    if (state.status !== 'playing') return;
+
+    // 역링크 허용이 꺼져있으면 특정 지점으로 점프 불가
+    if (!state.allowBacktracking) return;
+
+    const targetIndex = state.path.indexOf(nodeId);
+    // 경로에 없는 노드거나 이미 현재 노드면 무시
+    if (targetIndex === -1 || targetIndex === state.path.length - 1) return;
+
+    const newPath = state.path.slice(0, targetIndex + 1);
+
+    set({
+      currentDocId: nodeId,
+      path: newPath,
+      moves: state.moves + 1,
+      historyLog: [...state.historyLog, nodeId],
     });
   },
 

--- a/src/types/wikirace.ts
+++ b/src/types/wikirace.ts
@@ -10,6 +10,7 @@ export interface GameState {
   goalDocId: string | null;
   currentDocId: string | null;
   path: string[]; // Stack of document IDs visited
+  historyLog: string[]; // Full navigation log including backtracking steps
   moves: number;
   startTime: number | null;
   endTime?: number;


### PR DESCRIPTION
## Summary
- add navigation history tracking with jump-to-node support in the header modal when backtracking is allowed
- hide the path history panel by default and improve its layout with scrollable content and persistent controls
- visualize branching paths in the sidebar using the full navigation log for clearer backtracking paths

## Testing
- npm run lint *(fails: npm is not available in the environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69345ecc45b0832e8af0fc8d8975668c)