### PR TITLE
🐛 [Bug] Fixed bugs related to Leaderboard

### DIFF
--- a/src/components/PathReplay.tsx
+++ b/src/components/PathReplay.tsx
@@ -290,46 +290,54 @@ export function PathReplay({ entry }: PathReplayProps) {
         <div className="bg-white rounded-lg border p-6">
           <h3 className="text-gray-800 mb-4">경로 상세 분석</h3>
 
-          <div className="space-y-3">
-            <div className="flex items-start gap-3">
-              <div className="w-5 h-5 rounded bg-indigo-500 flex items-center justify-center text-white text-[10px] font-semibold mt-1">
-                1
-              </div>
-              <div className="flex-1">
-                <div className="text-gray-700">시작 문서</div>
-                <div className="text-gray-900">{entry.startDoc}</div>
-              </div>
-            </div>
+          <div className="space-y-3 max-h-[400px] overflow-y-auto">
+            {entry.path.map((docId, index) => {
+              const doc = mockWikiDocuments[docId];
+              const isStart = index === 0;
+              const isGoal = index === entry.path.length - 1;
 
-            <div className="flex items-start gap-3">
-              <div className="w-5 h-5 rounded bg-indigo-500 flex items-center justify-center text-white text-[10px] font-semibold mt-1">
-                {entry.path.length}
-              </div>
-              <div className="flex-1">
-                <div className="text-gray-700">목표 문서</div>
-                <div className="text-gray-900">{entry.goalDoc}</div>
-              </div>
-            </div>
-
-            <div className="flex items-start gap-3">
-              <div className="w-5 h-5 rounded bg-gray-400 flex items-center justify-center text-white text-[10px] font-semibold mt-1">
-                ···
-              </div>
-              <div className="flex-1">
-                <div className="text-gray-700">경유한 문서</div>
-                <div className="text-gray-900">
-                  {entry.path.length - 2}개의 중간 문서를 거쳐 도달
+              return (
+                <div key={`path-${index}-${docId}`} className="flex items-start gap-3">
+                  <div className={`w-7 h-7 rounded flex items-center justify-center text-white text-xs font-semibold mt-1 flex-shrink-0 ${
+                    isStart ? 'bg-green-500' : isGoal ? 'bg-red-500' : 'bg-indigo-500'
+                  }`}>
+                    {index + 1}
+                  </div>
+                  <div className="flex-1">
+                    <div className={`text-sm ${isStart || isGoal ? 'font-semibold' : ''} ${
+                      isStart ? 'text-green-700' : isGoal ? 'text-red-700' : 'text-gray-700'
+                    }`}>
+                      {isStart ? '🚀 시작 문서' : isGoal ? '🎯 목표 문서' : '📄 중간 문서'}
+                    </div>
+                    <div className="text-gray-900 font-medium">
+                      {doc?.title || '알 수 없음'}
+                    </div>
+                    <div className="text-xs text-gray-500">{docId}</div>
+                  </div>
+                  {index < entry.path.length - 1 && (
+                    <div className="text-gray-400 text-xl flex-shrink-0">↓</div>
+                  )}
                 </div>
-              </div>
-            </div>
+              );
+            })}
           </div>
 
           <div className="mt-6 p-4 bg-blue-50 rounded-lg">
             <div className="text-gray-700 mb-2">💡 전략 분석</div>
             <ul className="text-gray-600 space-y-1 text-sm">
-              <li>• 최소 이동: {entry.moves}회</li>
-              <li>• 평균 문서당 시간: {Math.round(entry.time / entry.moves)}초</li>
-              <li>• 효율성: {entry.score >= 700 ? '매우 높음' : entry.score >= 500 ? '높음' : '보통'}</li>
+              <li>• 총 이동 횟수: {entry.moves}회</li>
+              <li>• 실제 경로 길이: {entry.path.length}개 문서</li>
+              <li>• 평균 문서당 시간: {entry.moves > 0 ? Math.round(entry.time / entry.moves) : 0}초</li>
+              <li>• 효율성: {entry.score >= 700 ? '매우 높음 ⭐⭐⭐' : entry.score >= 500 ? '높음 ⭐⭐' : '보통 ⭐'}</li>
+              {hasBranches && (
+                <>
+                  <li>• 브랜치 수: {entry.branches.length}개 (탐색 시도 포함)</li>
+                  <li>• 전략 유형: 다양한 경로 탐색 후 최적 경로 선택</li>
+                </>
+              )}
+              {!hasBranches && (
+                <li>• 전략 유형: 직선 경로 (단일 경로 탐색)</li>
+              )}
             </ul>
           </div>
         </div>

--- a/src/components/WikiRaceGame.tsx
+++ b/src/components/WikiRaceGame.tsx
@@ -48,13 +48,15 @@ export function WikiRaceGame() {
             : gameState.startTime
               ? Math.floor((Date.now() - gameState.startTime) / 1000)
               : 0,
-        nickname: gameState.playerNickname || '내 플레이'
+        nickname: gameState.playerNickname || '내 플레이',
+        branches: gameState.branches,
+        pathRefs: gameState.pathRefs
       }
     : undefined;
 
-  // 게임 완료 시 10위 안에 드는지 확인
+  // 게임 완료 시 10위 안에 드는지 확인 (도전 모드일 때만)
   useEffect(() => {
-    if (status === 'finished' && gameState.score && !gameState.playerNickname) {
+    if (status === 'finished' && gameState.score && !gameState.playerNickname && gameMode === 'challenge') {
       // 리더보드에서 점수 목록 추출
       const currentLeaderboard = getMockLeaderboard();
       const leaderboardScores = currentLeaderboard.map(entry => entry.score);
@@ -72,7 +74,7 @@ export function WikiRaceGame() {
         setShowNameInput(true);
       }
     }
-  }, [status, gameState.score, gameState.playerNickname]);
+  }, [status, gameState.score, gameState.playerNickname, gameMode]);
 
   useEffect(() => {
     if (status === 'playing' || status === 'finished') {


### PR DESCRIPTION
# 🎮 Wiki Racing - 게임 기능 개선 및 버그 수정

## 📋 Summary
git push하는 과정에서 main에 push하는 바람에 가장 최근 commit만 PR에 포함되어있습니다.
가장 최근 커밋 세개(커밋 `a59754c`이후 세개)를 확인해주시면 감사하겠습니다.

https://github.com/user-attachments/assets/9568b2df-232c-4a60-a990-b0ff9ba03df6


이 PR은 Wiki Racing 게임의 핵심 기능인 브랜치 시각화, 리더보드 시스템, 그리고 경로 분석 기능을 대폭 개선하고 여러 버그를 수정합니다.  
### 기술 시연 영상 타임라인
- 0:00 - 0:07 : 도전 모드 게임플레이 1 (매우 쉬운 버전)
- 0:07 - 0:19 : 게임 종료 후 리더보드에 이름을 남김
- 0:19 - 0:30 : 리더보드에서 상세 경로보기가 어떻게 구현되어있는지 확인
- 0:30 - 0:50 : 도전 모드 게임플레이 2 (중간에 경로를 바꾼, 두개의 브랜치를 이동한 버전)
- 0:50 - 1:10 : 리더보드에 들어가지 못했을 경우 가장 아래에 본인 이름이 표시됨 / 경로 확인시 두개의 브랜치를 이동한 흔적과, 실제 이동경로가 아래에 정리되어있음.
- 1:10 - 1:36 : 역링크 허용을 하지 않았을 경우의 게임플레이 시연

## ✨ 주요 변경사항

### 1. 🌳 Git 스타일 브랜치 시각화 개선
- **PathHistory 컴포넌트**: 시간 기반 수직 레이아웃에서 Git 그래프 스타일의 수평 분기 레이아웃으로 변경
- **브랜치 포지셔닝 알고리즘**: 재귀적 브랜치 위치 계산 알고리즘 구현
  - 같은 높이에서 수평으로 분기되도록 개선
  - `nodeOrders` 추적으로 향후 기능 확장 준비
- **GameHeader 브랜치 생성**: 히스토리 노드 클릭 시 올바른 브랜치 생성
  - `pathRefs`를 사용하여 브랜치/인덱스 정확히 추적

### 2. 🏆 리더보드 시스템 구축
- **영구 저장소 구현**
  - `leaderboard.json`으로 초기 상위 10개 데이터 제공
  - localStorage 통합으로 세션 간 데이터 유지
  - 상위 10위 진입 시 닉네임 입력 및 자동 저장
  - 동적 정렬 및 순위 재계산

- **도전 모드 전용 기록**
  - 연습 모드에서는 리더보드 등재 불가
  - 도전 모드에서만 이름 입력 모달 표시

- **자동 난이도 계산**
  - 쉬움: `score ≥ 800 && moves ≤ 5`
  - 어려움: `score < 600 || moves ≥ 13`
  - 보통: 그 외

- **동적 메달 순위**
  - 신규 점수 추가 시 메달(금/은/동) 자동 조정
  - 순위 삽입 후 재계산

### 3. 🐛 중요 버그 수정

#### 리더보드 중복 등재 문제
- **증상**: 이름 입력 후 리더보드에 동일 항목이 2번 표시됨
- **원인**:
  - `entries` 계산 시 `currentRun` 포함
  - `useEffect`에서 `leaderboardData`에 추가 후 리렌더링
  - 재계산 시 `currentRun` + `leaderboardData`(이미 추가됨) → 중복
- **해결책**: 3중 중복 방지 로직 구현
  - `useRef`로 저장된 엔트리 추적
  - `leaderboardData` 중복 체크
  - `entries` 계산 시 중복 확인

#### 브랜치 경로 표시 오류
- **증상**: 게임에서 브랜치를 생성했지만 리더보드에서 직선 경로로 표시됨
- **원인**: `leaderboardEntry`에 `branches`와 `pathRefs` 정보 미포함
- **해결책**:
  - `WikiRaceGame.tsx`의 `leaderboardEntry`에 브랜치 정보 추가
  - `Leaderboard.tsx`의 타입 정의 및 저장 로직 업데이트
  - PathReplay는 이미 브랜치 렌더링 지원, 데이터만 전달하면 됨

#### 경로 상세 분석 하드코딩 문제
- **증상**: PathReplay의 경로 상세 분석과 전략 분석이 하드코딩된 텍스트로 표시
- **해결책**: 실제 경로 데이터 기반 동적 표시
  - 지나간 모든 문서를 순서대로 표시 (시작: 초록, 목표: 빨강)
  - 총 이동 횟수, 실제 경로 길이, 평균 시간 계산
  - 브랜치 사용 여부에 따른 전략 유형 표시

### 4. 🎨 UI/UX 개선
- **목표 노드 펄스 애니메이션**
  - 1.0x → 1.1x 스케일 애니메이션 (2초 주기)
  - 발광 그림자 효과
  - 목표 노드에 시선 집중

- **PathReplay 모달 오버플로우 수정**
  - 500px 고정 높이로 제한
  - 수평/수직 스크롤 추가
  - 뷰포트 초과 방지

## 📊 변경된 파일

```
 src/components/GameHeader.tsx     |  16 +-
 src/components/Leaderboard.tsx    | 297 +++++++++++++++++++++++++++++--
 src/components/NameInputModal.tsx |  93 ++++++++++
 src/components/PathHistory.tsx    | 110 ++++++++----
 src/components/PathReplay.tsx     | 360 ++++++++++++++++++++++++++++++--------
 src/components/WikiNodeTree.tsx   |  46 ++++-
 src/components/WikiRaceGame.tsx   | 156 +++++++++++------
 src/data/leaderboard.json         | 183 +++++++++++++++++++
 src/gameStore.ts                  |  92 +++-------
 src/types/wikirace.ts             |  10 ++
 10 files changed, 1101 insertions(+), 262 deletions(-)
```

## 🧪 테스트 방법

### 브랜치 시각화 테스트
1. 게임 시작
2. 몇 단계 진행 후 뒤로가기
3. 다른 경로 탐색 (브랜치 생성)
4. "목록보기" 클릭하여 Git 스타일 브랜치 확인

### 리더보드 테스트
1. **도전 모드**에서 게임 완료
2. 10위 안에 드는 점수 획득
3. 닉네임 입력 모달 확인
4. 리더보드에서 중복 없이 1개만 등재되는지 확인
5. "경로 보기" 클릭 시 브랜치 구조가 게임 플레이와 동일한지 확인

### 연습 모드 테스트
1. **연습 모드**에서 게임 완료
2. 닉네임 입력 모달이 나타나지 않는지 확인
3. 리더보드에 등재되지 않는지 확인

### 경로 분석 테스트
1. 리더보드에서 임의의 항목 "경로 보기" 클릭
2. 경로 상세 분석에 실제 경로가 표시되는지 확인
3. 전략 분석에 동적 계산된 값이 표시되는지 확인

## 🔧 기술적 개선사항

- **타입 안정성**: `LeaderboardEntry` 인터페이스에 `branches`, `pathRefs` 추가
- **상태 관리**: `nodeOrders` 필드로 브랜치 노드 순서 추적
- **중복 방지**: `useRef`와 상태 비교를 통한 3중 검증
- **알고리즘**: 재귀적 브랜치 시작 행 계산 알고리즘

## 📝 Breaking Changes

없음 - 모든 변경사항은 하위 호환성 유지

## 🎯 후속 작업
- [ ] 실제 나무위키와 연동작업
- [ ] Word2Vec을 이용해 난이도를 계산하는 기능 → 실제 AI를 이용해 최적의 경로를 탐색한 후 난이도 책정 방식으로 발전
- [ ] 역링크 허용 여부에 따라 난이도 계산 변화
- [ ] 브랜치 병합(merge) 기능 추가
- [ ] 리더보드 페이지네이션 (10개 이상)
- [ ] 경로 비교 기능
- [ ] 소셜 공유 기능

